### PR TITLE
float_to_ascii

### DIFF
--- a/float_to_ascii.c
+++ b/float_to_ascii.c
@@ -5,16 +5,10 @@ float value;
 char queue[4];
 
 char* float_to_ascii(float value){
-    value+=33.33;
+    int decimal = (int)value;
+    int tenth = (int)((value - decimal) * 100);
     
-    int decimal= (int)value; // 33.00
-    int tenth= value*100 - decimal*100; // 00.33
-    
-    queue[0]=(char)decimal;
-    queue[1]='.';
-    queue[2]=(char)tenth;
-    queue[3]='\0';
-    
+    sprintf(queue, "%d.%02d", decimal, tenth);
     return queue;
 }
 

--- a/float_to_ascii_func.c
+++ b/float_to_ascii_func.c
@@ -2,18 +2,10 @@ float value;
 int data_no;
 char queue[20][4];
 
-char* float_to_ascii(float value, int data_no){
-    value+=33.33;
+char* float_to_ascii(float value, int data_no) {
+    int decimal = (int)value;
+    int tenth = (int)((value - decimal) * 100);
     
-    int decimal= (int)value; // 33.00
-    int tenth= value*100 - decimal*100; // 00.33
-    
-   
-    queue[data_no][0]=(char)decimal;
-    queue[data_no][1]='.';
-    queue[data_no][2]=(char)tenth;
-    queue[data_no][3]='\0';
-       
-    
+    sprintf(queue[data_no], "%d.%02d", decimal, tenth);
     return queue[data_no];
 }


### PR DESCRIPTION
Kodun temel fikri iyi görünüyor, ancak bazı sorunlar var.

Bir sorun, decimal ve ondalık bölümlerini saklamak için 'char' türününü kullanmışsın. 'char' türü, sayıları değil, karakterleri saklamak içindir ve 'queue[0]' ve 'queue[2]' değişkenlerinde saklanan değerler, oluşan casting sonrası gerçekte decimal ve ondalık bölümleri olmayabilir. Bunun yerine 'sprintf()' çağrısı içinde '%d' ve '%d' biçimlendirme belirteçlerini kullanarak decimal ve ondalık bölümlerin tamsayı değerlerini 'queue' dizgesine yazabiliriz.

Diğer bir sorun ise girdi değerine 33.33 değerinin eklenmen. Bu, girdi değerinin yakın olduğu bir sayı olmaması durumunda fonksiyonun beklenmedik sonuçlar üretebileceği anlamına geliyor.

Ayrıca, ondalık kısım kesilirken "0" dan "9" a kadar ascii değerlerinde 48 ile 57 arasındadır, bu yüzden ondalık kısmın ascii temsili için 48 eklemen gerekiyor.

umarım yardımcı olabilmişimdir.